### PR TITLE
Fix false positive when using chai-as-promised

### DIFF
--- a/src/chai-xml.js
+++ b/src/chai-xml.js
@@ -78,7 +78,7 @@ var chaiXmlPlugin = function chaiXmlPlugin(chai, utils){
                     });
                 });
             } else {
-                _super.apply(this, arguments);
+                return _super.apply(this, arguments);
             }
         };
     };


### PR DESCRIPTION
# The issue

When we use both chai-as-promised and chai-xml, chai-xml inhibits the behavior of chai-as-promised with the `eventually` keyword.

`eventually` has to be used in a return statement so we can test the promise result.

# Steps to reproduce

1. Download the attached project: [foo.zip](https://github.com/krampstudio/chai-xml/files/5355881/foo.zip)
2. Unzip and inside the foo/ folder, run `npm install`
3. Run the below command:

```bash
$ ./node_modules/mocha/bin/mocha ./index-spec.js
```

## Actual Result

```
  Fancy describe
    ✓ should fail
(node:9563) UnhandledPromiseRejectionWarning: AssertionError: expected 4 to equal 3
    at /tmp/foo/node_modules/chai-as-promised/lib/chai-as-promised.js:302:22
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    ....
```

## Expected result

(You can comment `chai.use(require("chai-xml"));` in `index-spec.js` to see the expected result)

```
  Fancy describe
    1) should fail


  0 passing (6ms)
  1 failing

  1) Fancy describe
       should fail:

      AssertionError: expected 4 to equal 3
      + expected - actual

      -4
      +3
      
      at /tmp/foo/node_modules/chai-as-promised/lib/chai-as-promised.js:302:22
```

# Explanation of the patch

Simply use the return statement to make a clean by-pass to other hooks.